### PR TITLE
Update the example to support the new Decode() function

### DIFF
--- a/_example/example.go
+++ b/_example/example.go
@@ -40,13 +40,12 @@ func main() {
 	log.Println("Start streaming")
 	go func() {
 		for {
-			var tmp image.Image
-			err = dec.Decode(&tmp)
+			decodedImage, err := dec.Decode()
 			if err != nil {
 				break
 			}
 			mutex.Lock()
-			img = tmp
+			img = decodedImage
 			mutex.Unlock()
 		}
 	}()


### PR DESCRIPTION
Commit 569f8b572a930f7cef83dad9a7f0f190b9c0a64b changed the Decode() function to create a new image within itself. In doing so it removed taking a empty image as a parameter. However, the example was not updated and does not compile. This fixes that issue by removing the now unnecessary argument of type `*image.Image` from the `Decode()` function.