### PR TITLE
added function to fetch the full multipart message so we can read the…

### DIFF
--- a/mjpeg.go
+++ b/mjpeg.go
@@ -60,7 +60,7 @@ func (d *Decoder) Decode() (image.Image, error) {
 	return jpeg.Decode(p)
 }
 
-//Don't decode image, just return the multipart data structure
+//　Part just return the multipart data structure
 func (d *Decoder) Part() (*multipart.Part, error) {
 	p, err := d.r.NextPart()
 	if err != nil {

--- a/mjpeg.go
+++ b/mjpeg.go
@@ -60,6 +60,15 @@ func (d *Decoder) Decode() (image.Image, error) {
 	return jpeg.Decode(p)
 }
 
+//Don't decode image, just return the multipart data structure
+func (d *Decoder) Part() (*multipart.Part, error) {
+	p, err := d.r.NextPart()
+	if err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
 // DecodeRaw do decoding raw bytes
 func (d *Decoder) DecodeRaw() ([]byte, error) {
 	p, err := d.r.NextPart()


### PR DESCRIPTION
Instead of just calling Decode() and getting the decoded jpeg image without headers, this call allows clients the option to read headers from the multipart messages as they come in.